### PR TITLE
Refactor class-specific options into classes directly

### DIFF
--- a/pybm/builders/base.py
+++ b/pybm/builders/base.py
@@ -18,6 +18,9 @@ class PythonEnvBuilder:
         if wheel_cache_string != "":
             self.wheel_caches = wheel_cache_string.split(":")
 
+    def add_arguments(self, command: str):
+        raise NotImplementedError
+
     def create(self,
                executable: Union[str, Path],
                destination: Union[str, Path],
@@ -28,8 +31,8 @@ class PythonEnvBuilder:
     def delete(self, env_dir: Union[str, Path], verbose: bool = False) -> None:
         raise NotImplementedError
 
-    def link_existing(self, env_dir: Union[str, Path],
-                      verbose: bool = False) -> PythonSpec:
+    def link(self, env_dir: Union[str, Path], verbose: bool = False) \
+            -> PythonSpec:
         raise NotImplementedError
 
     def install_packages(self,

--- a/pybm/commands/compare.py
+++ b/pybm/commands/compare.py
@@ -38,33 +38,15 @@ class CompareCommand(CLICommand):
                                       "differences are reported. An error is "
                                       "raised if any of the given "
                                       "refs are not present in the run.")
-        self.parser.add_argument("--target-filter",
-                                 type=str,
-                                 default=None,
-                                 metavar="<regex>",
-                                 help="Regex filter to selectively report "
-                                      "benchmark target files. If specified, "
-                                      "only benchmark files matching the "
-                                      "given filter will be included "
-                                      "in the report.")
-        self.parser.add_argument("--benchmark-filter",
-                                 type=str,
-                                 default=None,
-                                 metavar="<regex>",
-                                 help="Regex filter to selectively report "
-                                      "benchmarks from the matched target "
-                                      "files. If specified, only benchmarks "
-                                      "matching the given filter will be "
-                                      "included in the report.")
-        self.parser.add_argument("--context-filter",
-                                 type=str,
-                                 default=None,
-                                 metavar="<regex>",
-                                 help="Regex filter for additional context to "
-                                      "report from the benchmarks. If "
-                                      "specified, only context values "
-                                      "matching the given context filter "
-                                      "will be included in the report.")
+
+        reporter: BenchmarkReporter = get_reporter_class(config=self.config)
+        reporter_name = self.config.get_value("reporter.className")
+        reporter_group_desc = f"Additional options from configured " \
+                              f"reporter class {reporter_name!r}"
+        reporter_group = self.parser.add_argument_group(reporter_group_desc)
+        # add builder-specific options into the group
+        for arg in reporter.add_arguments():
+            reporter_group.add_argument(arg.pop("flags"), **arg)
 
     def run(self, args: List[str]) -> int:
         if not args:

--- a/pybm/commands/report.py
+++ b/pybm/commands/report.py
@@ -33,33 +33,14 @@ class ReportCommand(CLICommand):
                                  metavar="<ref>",
                                  help="Reference to display benchmark results "
                                       "for. Mandatory.")
-        self.parser.add_argument("--target-filter",
-                                 type=str,
-                                 default=None,
-                                 metavar="<regex>",
-                                 help="Regex filter to selectively report "
-                                      "benchmark target files. If specified, "
-                                      "only benchmark files matching the "
-                                      "given filter will be included "
-                                      "in the report.")
-        self.parser.add_argument("--benchmark-filter",
-                                 type=str,
-                                 default=None,
-                                 metavar="<regex>",
-                                 help="Regex filter to selectively report "
-                                      "benchmarks from the matched target "
-                                      "files. If specified, only benchmarks "
-                                      "matching the given filter will be "
-                                      "included in the report.")
-        self.parser.add_argument("--context-filter",
-                                 type=str,
-                                 default=None,
-                                 metavar="<regex>",
-                                 help="Regex filter for additional context to "
-                                      "report from the benchmarks. If "
-                                      "specified, only context values "
-                                      "matching the given context filter "
-                                      "will be included in the report.")
+        reporter: BenchmarkReporter = get_reporter_class(config=self.config)
+        reporter_name = self.config.get_value("reporter.className")
+        reporter_group_desc = f"Additional options from configured " \
+                              f"reporter class {reporter_name!r}"
+        reporter_group = self.parser.add_argument_group(reporter_group_desc)
+        # add builder-specific options into the group
+        for arg in reporter.add_arguments():
+            reporter_group.add_argument(arg.pop("flags"), **arg)
 
     def run(self, args: List[str]) -> int:
         if not args:

--- a/pybm/reporters/base.py
+++ b/pybm/reporters/base.py
@@ -13,6 +13,9 @@ class BenchmarkReporter:
             "reporter.significantDigits"
         )
 
+    def add_arguments(self):
+        raise NotImplementedError
+
     def compare(self,
                 *refs: str,
                 result: Union[str, Path],

--- a/pybm/reporters/console.py
+++ b/pybm/reporters/console.py
@@ -52,7 +52,6 @@ def rescale(key: str, time_value: Tuple[float, float],
 
 def reduce(bm: Dict[str, List[Any]]) -> Dict[str, Any]:
     res: Dict[str, Any] = {}
-    # TODO: Enable user-defined reducers
     for k, v in bm.items():
         if isinstance(v[0], str):
             assert len(set(v)) == 1, \
@@ -220,6 +219,36 @@ class JSONConsoleReporter(BenchmarkReporter):
             res = f"{tval:.{digits}f} ± {std:.{digits}f}"
         return res
 
+    def add_arguments(self):
+        args = [{"flags": "--target-filter",
+                 "type": str,
+                 "default": None,
+                 "metavar": "<regex>",
+                 "help": "Regex filter to selectively report "
+                         "benchmark target files. If specified, "
+                         "only benchmark files matching the "
+                         "given filter will be included "
+                         "in the report."},
+                {"flags": "--benchmark-filter",
+                 "type": str,
+                 "default": None,
+                 "metavar": "<regex>",
+                 "help": "Regex filter to selectively "
+                         "report benchmarks from the matched target "
+                         "files. If specified, only benchmarks "
+                         "matching the given filter will be "
+                         "included in the report."},
+                {"flags": "--context-filter",
+                 "type": str,
+                 "default": None,
+                 "metavar": "<regex>",
+                 "help": "Regex filter for additional context "
+                         "to report from the benchmarks. If "
+                         "specified, only context values "
+                         "matching the given context filter "
+                         "will be included in the report."}]
+        return args
+
     def compare(self,
                 *refs: str,
                 result: Union[str, Path],
@@ -274,8 +303,9 @@ class JSONConsoleReporter(BenchmarkReporter):
              target_filter: Optional[str] = None) -> List[Dict[str, Any]]:
         path = Path(self.result_dir) / result / ref
         if not path.exists() or not path.is_dir():
-            raise PybmError(f"Given result path {result} does not exist, or "
-                            f"is not a directory.")
+            raise PybmError(
+                f"Given result path {result} does not exist, or "
+                f"is not a directory.")
         json_files = list_contents(path=path,
                                    file_suffix=".json",
                                    names_only=False)
@@ -293,7 +323,8 @@ class JSONConsoleReporter(BenchmarkReporter):
 
         header_widths = lmap(len, formatted_results[0].keys())
         data_widths = zip(header_widths,
-                          *(lmap(len, d.values()) for d in formatted_results))
+                          *(lmap(len, d.values()) for d in
+                            formatted_results))
         column_widths: List[int] = lmap(max, data_widths)
         padding = self.padding
         for i, res in enumerate(formatted_results):

--- a/pybm/runners/base.py
+++ b/pybm/runners/base.py
@@ -33,6 +33,9 @@ class BenchmarkRunner:
             runner_util.load_context_providers(config.get_value(
                 "runner.contextProviders"))
 
+    def add_arguments(self):
+        raise NotImplementedError
+
     def check_required_packages(self, environment: BenchmarkEnvironment):
         missing_pkgs = []
         installed = environment.get_value("python.packages")

--- a/pybm/runners/gbm.py
+++ b/pybm/runners/gbm.py
@@ -41,14 +41,17 @@ class GoogleBenchmarkRunner(BenchmarkRunner):
                 f"Google Benchmark on any platform or Python "
                 f"interpreter outside this group, you will have "
                 f"to build the wheel from source. This requires "
-                f"Bazel; for information on Bazel installation, "
-                f"see "
+                f"Bazel; for information on Bazel installation, see "
                 f"https://docs.bazel.build/versions/4.2.1/install.html.")
         super().__init__(config=config)
         self.with_interleaving: bool = config.get_value(
             "runner.GoogleBenchmarkWithRandomInterleaving")
         self.aggregates_only: bool = config.get_value(
             "runner.GoogleBenchmarkSaveAggregatesOnly")
+
+    def add_arguments(self):
+        # TODO: Add GBM command line options
+        return []
 
     def create_flags(
             self,

--- a/pybm/runners/stdlib.py
+++ b/pybm/runners/stdlib.py
@@ -22,6 +22,9 @@ class TimeitRunner(BenchmarkRunner):
     def __init__(self, config: PybmConfig):
         super().__init__(config=config)
 
+    def add_arguments(self):
+        return []
+
     def parse_flags(self, flags: List[str]):
         prefix = self.prefix
         parser = argparse.ArgumentParser(prog=self.__class__.__name__,

--- a/pybm/runners/util.py
+++ b/pybm/runners/util.py
@@ -8,7 +8,7 @@ from pybm.exceptions import PybmError, GitError
 from pybm.specs import Worktree
 from pybm.util.common import lfilter, dfilter, dkfilter, lmap
 from pybm.util.functions import is_context_provider
-from pybm.util.git import get_from_history, clean_worktree, has_untracked_files
+from pybm.util.git import get_from_history
 from pybm.util.imports import import_from_module
 from pybm.util.path import get_subdirs, list_contents
 from pybm.util.print import abbrev_home
@@ -47,7 +47,7 @@ def discover_targets(worktree: Worktree,
           f"{ref_type} {ref!r}.")
     try:
         if source_ref is not None:
-            if has_untracked_files(root):
+            if worktree.has_untracked_files():
                 raise PybmError("Sourcing benchmarks from other git "
                                 "reference requires a clean worktree, "
                                 "but there are "
@@ -91,7 +91,7 @@ def discover_targets(worktree: Worktree,
             # restore benchmark contents from original ref
             get_from_history(ref=ref, resource=source_path, directory=root)
             # revert checkout of untracked files with `git clean`
-            clean_worktree(directory=root)
+            worktree.clean()
             print(f"Finished benchmark run in worktree "
                   f"{abbrev_home(root)} on {ref_type} {ref!r}.")
 


### PR DESCRIPTION
This commit transfers some of the hardcoded options for certain CLI commands into the appropriate class interfaces. As a result, CLI options change dynamically now given the choice of runner, builder and reporter class.

Additionally, the options are semantically grouped together and separated from other, fixed options into an argparse argument group. This allows for some prettier printing for help texts.