### PR TITLE
Extend git worktree class interface, add more functionality

### DIFF
--- a/pybm/config.py
+++ b/pybm/config.py
@@ -69,7 +69,7 @@ class PybmConfig(StateMixin):
         print(f"Describing configuration option {attr!r}.")
         print(f"Value type:    {value_type}")
         print(f"Current value: {current!r}")
-        print(description_db[group][name] or
+        print(description_db[group].get(name, "") or
               f"No description available for {group} attribute {name}.")
 
 
@@ -182,7 +182,7 @@ description_db: Dict[str, Descriptions] = {
                      "benchmarks inside Python virtual environments. If you "
                      "want to supply your own custom runner class, set this "
                      "value to point to your custom subclass of "
-                     "pybm.runners.BenchmarkRunner.",
+                     "pybm.runners.base.BenchmarkRunner.",
         "failFast": "",
         "numRepetitions": "",
         "contextProviders": "",

--- a/pybm/mixins.py
+++ b/pybm/mixins.py
@@ -26,17 +26,15 @@ class StateMixin:
             else:
                 return default
 
-    def set_value(self, attr: str, value: Any, typecheck: bool = True):
+    def set_value(self, attr: str, value: Any):
         *subkeys, key = attr.split(".")
         obj = self
         for subkey in subkeys:
             obj = getattr(obj, subkey, None)
         if obj is None or not hasattr(obj, key):
-            # print("failed.")
             raise PybmError(f"Class {self.__class__.__name__!r} has no "
                             f"attribute {attr!r}.")
-        if typecheck:
-            value = self.canonicalize_type(obj, key, value)
+        value = self.canonicalize_type(obj, key, value)
         setattr(obj, key, value)
         return self
 
@@ -48,7 +46,6 @@ class StateMixin:
         try:
             if target_type != bool:
                 # int, float, str
-                # TODO: Maybe scrutinize string inputs for if they make sense?
                 return target_type(value)
             else:
                 # bool(s) is True for all strings except the empty string,
@@ -62,7 +59,6 @@ class StateMixin:
                     # do not allow shorthands, y/n, 1/0 etc.
                     raise ValueError
         except ValueError:
-            print("failed.")
             raise PybmError(f"Configuration value {attr!r} of class "
                             f"{obj.__class__.__name__} has to be of type "
                             f"{target_type.__name__!r}, but the given "

--- a/pybm/util/print.py
+++ b/pybm/util/print.py
@@ -1,14 +1,16 @@
 import os
-from typing import List, Iterable
+from pathlib import Path
+from typing import List, Iterable, Union
 
 from pybm.util.common import lmap
 
 
-def abbrev_home(path: str) -> str:
+def abbrev_home(path: Union[str, Path]) -> str:
+    str_path = str(path)
     home_dir = os.getenv("HOME")
-    if home_dir is not None and path.startswith(home_dir):
-        path = path.replace(home_dir, "~")
-    return path
+    if home_dir is not None and str_path.startswith(home_dir):
+        str_path = str_path.replace(home_dir, "~")
+    return str_path
 
 
 def calculate_column_widths(data: Iterable[Iterable[str]]) -> List[int]:


### PR DESCRIPTION
This commit adds more git functionality to the current interface, needed for checkout mode and in-place updates. Additionally, some getter/setter workarounds were deleted due to them no longer being in use.

Also, git worktree ops are now wrapped into a print context manager, just as done for the virtual environment builder class.