### PR TITLE
Add black pre-commit hook, sum example GitHub test job, new `git work…

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,11 +12,39 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repo
+      - name: Check out pybm
         uses: actions/checkout@v2
+
       - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
+
       - name: Run pre-commit hooks
         uses: pre-commit/action@v2.0.3
+
+  example-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out pybm
+        uses: actions/checkout@v2
+
+      - name: Check out example
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          repository: nicholasjng/pybm-sum-example
+          path: sum-example
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Run sum example test
+        run: |
+          python -m pip install .
+          pybm init
+          pybm run -m benchmarks master linear-time constant-time --checkouts
+          pybm compare latest master linear-time constant-time
+        working-directory: sum-example

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://gitlab.com/pycqa/flake8
-  rev: '3.9.2'
+  rev: '4.0.1'
   hooks:
   - id: flake8
 
@@ -9,3 +9,9 @@ repos:
   hooks:
   - id: mypy
     files: pybm/
+
+- repo: https://github.com/psf/black
+  rev: 21.10b0
+  hooks:
+    - id: black
+      language_version: python3

--- a/benchmarks/sum.py
+++ b/benchmarks/sum.py
@@ -1,9 +1,0 @@
-import pybm
-
-
-def f():
-    return sum(range(100000))
-
-
-if __name__ == "__main__":
-    pybm.run(context=globals())

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,7 @@ def get_requirements() -> list[str]:
 def get_extras():
     """Extra pybm functionality, specified as a valid argument to
     setuptools.setup's 'extras_require' keyword argument."""
-    extra_features = {
-        "gbm": ["google-benchmark==0.2.0"]
-    }
+    extra_features = {"gbm": ["git+https://github.com/google/benchmark"]}
     extra_features["all"] = sum(extra_features.values(), start=[])
     return extra_features
 
@@ -20,7 +18,7 @@ def get_version(fp) -> str:
     with open(fp, "r") as f:
         for line in f:
             if "version" in line:
-                delim = "\""
+                delim = '"'
                 return line.split(delim)[1]
     raise RuntimeError(f"could not find a valid version string in {fp}.")
 
@@ -28,15 +26,13 @@ def get_version(fp) -> str:
 setup(
     name="pybm",
     version=get_version("pybm/__init__.py"),
-    description="A Python CLI for reproducible benchmarking in a git "
-                "repository.",
+    description="A Python CLI for reproducible benchmarking in a git repository.",
     packages=find_packages(),
     install_requires=get_requirements(),
     extras_require=get_extras(),
-    entry_points={
-        'console_scripts': ['pybm=pybm.main:main']
-    },
+    entry_points={"console_scripts": ["pybm=pybm.main:main"]},
+    exclude=["tests"],
     author="Nicholas Junge",
     license="Apache-2.0",
-    url="https://github.com/nicholasjng/pybm"
+    url="https://github.com/nicholasjng/pybm",
 )


### PR DESCRIPTION
…tree APIs`

This commit has two main contents:
* psf/black pre-commit hook to format source files;
* A GitHub Actions job end-to-end testing the sum example on pybm builtin dependencies,