### PR TITLE
Fix numerous pybm bugs and crashes

### DIFF
--- a/pybm/commands/env.py
+++ b/pybm/commands/env.py
@@ -103,23 +103,7 @@ class EnvCommand(CLICommand):
                 "recognized as a valid Python "
                 "virtual environment.",
             )
-        elif subcommand == "delete":
-            self.parser.add_argument(
-                "identifier",
-                metavar="<identifier>",
-                help="Information that uniquely "
-                "identifies the environment. "
-                "Can be name, checked out "
-                "commit/branch/tag name or "
-                "git worktree base directory.",
-            )
-            self.parser.add_argument(
-                "-f",
-                "--force",
-                action="store_true",
-                help="Force worktree removal, including untracked files and changes.",
-            )
-        elif subcommand == "install":
+        elif subcommand in ["delete", "install", "uninstall"]:
             self.parser.add_argument(
                 "identifier",
                 metavar="<id>",
@@ -129,65 +113,14 @@ class EnvCommand(CLICommand):
                 "commit/branch/tag name, "
                 "or worktree root directory.",
             )
-            self.parser.add_argument(
-                "packages",
-                nargs="*",
-                default=None,
-                metavar="<packages>",
-                help="Packages to install into the new virtual environment using pip.",
-            )
-            self.parser.add_argument(
-                "-r",
-                type=str,
-                default=None,
-                metavar="<requirements>",
-                dest="requirements_file",
-                help="Requirements file for dependency "
-                "installation in the newly created "
-                "virtual environment.",
-            )
-            self.parser.add_argument(
-                "--pip-options",
-                nargs="*",
-                default=None,
-                help="Space-separated list of command "
-                "line options for dependency "
-                "installation in the created"
-                "virtual environment using "
-                "`pip install`. To get a "
-                "comprehensive list of options, "
-                "run `python -m pip install -h`.",
-                metavar="<pip-options>",
-            )
-        elif subcommand == "uninstall":
-            self.parser.add_argument(
-                "identifier",
-                metavar="<id>",
-                help="Information that uniquely "
-                "identifies the environment. "
-                "Can be name, checked out "
-                "commit, branch name, directory, "
-                "or custom user-defined tags.",
-            )
-            self.parser.add_argument(
-                "packages",
-                nargs="+",
-                metavar="<packages>",
-                help="Packages to uninstall from the benchmark environment using pip.",
-            )
-            self.parser.add_argument(
-                "--pip-options",
-                nargs="*",
-                default=None,
-                help="Space-separated list of command "
-                "line options for dependency "
-                "removal in the benchmark "
-                "environment using "
-                "`pip uninstall`. To get a "
-                "comprehensive list of options, "
-                "run `python -m pip uninstall -h`.",
-                metavar="<pip-options>",
-            )
+            if subcommand == "delete":
+                self.parser.add_argument(
+                    "-f",
+                    "--force",
+                    action="store_true",
+                    help="Force worktree removal, "
+                    "including untracked files and changes.",
+                )
         elif subcommand == "list":
             pass
         elif subcommand == "update":

--- a/pybm/commands/init.py
+++ b/pybm/commands/init.py
@@ -63,8 +63,8 @@ class InitCommand(CLICommand):
         config_path = config_dir / "config.yaml"
 
         if options.remove_existing:
-            for p in list_contents(config_dir):
-                (config_dir / p).unlink(missing_ok=True)
+            for p in list_contents(config_dir, file_suffix=".yaml", names_only=True):
+                (config_dir / p).unlink()
 
         if config_path.exists():
             raise PybmError(

--- a/pybm/commands/run.py
+++ b/pybm/commands/run.py
@@ -197,6 +197,8 @@ class RunCommand(CLICommand):
                 environment = env_store.get(env_id)
 
             worktree = environment.worktree
+            ref, ref_type = worktree.get_ref_and_type()
+
             subdir = create_subdir(result_dir=result_dir, worktree=worktree)
 
             runner.check_required_packages(environment=environment)
@@ -207,14 +209,14 @@ class RunCommand(CLICommand):
                 n = len(benchmark_targets)
                 if n > 0:
                     print(
-                        f"Found a total of {n} benchmark targets for "
-                        f"environment {environment.name!r}."
+                        f"Found a total of {n} benchmark targets for {ref_type} "
+                        f"{ref!r} in environment {environment.name!r}."
                     )
                 else:
                     msg = (
-                        f"Benchmark selector {source_path!r} did not "
-                        f"match any directory or Python files in "
-                        f"environment {environment.name!r}."
+                        f"Benchmark selector {str(source_path)!r} did not "
+                        f"match any directory or Python files for {ref_type} "
+                        f"{ref!r} in environment {environment.name!r}."
                     )
 
                     if runner.fail_fast:

--- a/pybm/env_store.py
+++ b/pybm/env_store.py
@@ -227,9 +227,10 @@ class EnvironmentStore:
 
         env_data = [column_names]
         for env in self.environments:
+            root: str = env.get_value("worktree.root")
+
             values = [env.get_value("name")]
             values.extend(env.worktree.get_ref_and_type())
-            root: str = env.get_value("worktree.root")
             values.append(abbrev_home(root))
             values.append(env.get_value("python.version"))
             env_data.append(values)

--- a/pybm/reporters/console.py
+++ b/pybm/reporters/console.py
@@ -372,7 +372,8 @@ class JSONConsoleReporter(BenchmarkReporter):
 
         if not path.exists() or not path.is_dir():
             raise PybmError(
-                f"Given result path {result!r} does not exist, or is not a directory."
+                f"Given result path {str(path)!r} does not exist, "
+                f"or is not a directory."
             )
 
         json_files = list_contents(path=path, file_suffix=".json")

--- a/pybm/runners/util.py
+++ b/pybm/runners/util.py
@@ -4,7 +4,7 @@ import re
 from pathlib import Path
 from typing import List, Any, Dict, Union, Optional, Tuple
 
-from pybm.exceptions import PybmError, GitError
+from pybm.exceptions import PybmError
 from pybm.specs import Worktree
 from pybm.util.common import lfilter, dfilter, dkfilter, lmap
 from pybm.util.functions import is_context_provider
@@ -71,7 +71,7 @@ def discover_targets(
                 )
 
             print(
-                f"Checking out benchmark resource {source_path!r} from git "
+                f"Checking out benchmark resource {str(source_path)!r} from git "
                 f"reference {source_ref!r} into worktree {abbrev_home(root)!r}."
             )
 
@@ -109,9 +109,6 @@ def discover_targets(
 
         yield benchmark_targets
 
-    except GitError:
-        # Error in the benchmark or JSON writing
-        pass
     finally:
         if source_ref is not None and checkout_complete:
             # restore benchmark contents from original ref

--- a/pybm/util/git.py
+++ b/pybm/util/git.py
@@ -1,15 +1,20 @@
 import re
+import typing
 from functools import partial
 from pathlib import Path
-from typing import Tuple, Dict, Union, Optional, Literal
+from typing import Tuple, Dict, Union, Optional
+
+if typing.TYPE_CHECKING:
+    # Literal exists only from Python 3.8 onwards
+    # solution source:
+    # https://github.com/pypa/pip/blob/main/src/pip/_internal/utils/subprocess.py
+    from typing import Literal
 
 from pybm.exceptions import GitError
 from pybm.util.common import lmap, lfilter, version_tuple, version_string
 from pybm.util.subprocess import run_subprocess
 
 git_subprocess = partial(run_subprocess, ex_type=GitError)
-
-BranchMode = Literal["local", "remote", "all"]
 
 
 def get_git_version() -> Tuple[int, ...]:
@@ -121,7 +126,7 @@ def map_commits_to_tags() -> Dict[str, str]:
     return dict(split_list)
 
 
-def list_branches(mode: BranchMode = "all"):
+def list_branches(mode: 'Literal["local", "remote", "all"]' = "all"):
     def format_branch(name: str):
         name = name.lstrip(" *+")
         return name.split("/", maxsplit=2)[-1]

--- a/pybm/util/subprocess.py
+++ b/pybm/util/subprocess.py
@@ -1,17 +1,21 @@
 import subprocess
+import typing
 from pathlib import Path
-from typing import List, Tuple, Union, Literal
-
+from typing import List, Tuple, Union
 from pybm.exceptions import PybmError
 
-Handling = Literal["raise", "ignore"]
+if typing.TYPE_CHECKING:
+    # Literal exists only from Python 3.8 onwards
+    # solution source:
+    # https://github.com/pypa/pip/blob/main/src/pip/_internal/utils/subprocess.py
+    from typing import Literal
 
 
 def run_subprocess(
     command: List[str],
     allowed_statuscodes: List[int] = None,
     ex_type: type = PybmError,
-    errors: Handling = "raise",
+    errors: 'Literal["raise", "ignore"]' = "raise",
     cwd: Union[str, Path] = None,
 ) -> Tuple[int, str]:
     full_command = " ".join(command)


### PR DESCRIPTION
This commit is a hotfix for several bugs and crashes discovered shortly after the 0.0.2 release. This includes:

* Fix typing.Literal import to allow imports for Python 3.7.
* Add pybm to the list of required runner packages, trying to avoid surprises when running benchmarks.
* Fix a bad print in the `ConsoleReporter`'s `load` method, printing only the folder name instead of the whole path.
* Remove the `missing_ok=True` argument from `unlink` in `pybm init` to support Python 3.7.
* Print out the current ref and ref type in checkout mode.
* Remove hardcoded builder options from `pybm env install / uninstall`, which were previously breaking these commands due to command duplication.
* Fix unhandled GitError exceptions in the benchmark discovery context manager which led to runtime errors due to a missing yield.

Most if not all caught by @YPFoerster in a benchmark run on Python 3.7. Even though Python 3.7 is old(er), it should still be supported. 