### PR TITLE
Change from YAML to TOML for configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ work correctly. To check your git version, run `git --version`, which
 should result in an output showing the version number, similar to the one above.
 
 On the Python side, in its most standard configuration, **pybm** works almost
-entirely within the Python standard library - only the `pyyaml` package is
+entirely within the Python standard library - only the `toml` package is
 required for configuration management. Additional functionality is available via
 extras installation:
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
 show_error_codes = True
 
-[mypy-yaml]
+[mypy-toml]
 ignore_missing_imports = True

--- a/pybm/__init__.py
+++ b/pybm/__init__.py
@@ -25,7 +25,7 @@ def run(argv: Optional[List[str]] = None, context: Dict[str, Any] = None) -> int
             'this e.g. by passing "globals()" as a value for '
             "the context object."
         )
-    config_file = PybmConfig.load(".pybm/config.yaml")
+    config_file = PybmConfig.load()
     runner: BaseRunner = get_runner_class(config_file)
     runner.run_benchmark(argv, context=context)
     return SUCCESS

--- a/pybm/commands/compare.py
+++ b/pybm/commands/compare.py
@@ -18,7 +18,7 @@ class CompareCommand(CLICommand):
 
     def __init__(self):
         super(CompareCommand, self).__init__(name="compare")
-        self.config = PybmConfig.load(".pybm/config.yaml")
+        self.config = PybmConfig.load()
 
     def add_arguments(self):
         self.parser.add_argument(

--- a/pybm/commands/config.py
+++ b/pybm/commands/config.py
@@ -55,8 +55,7 @@ class ConfigCommand(CLICommand):
                 type=str,
                 metavar="<option>",
                 help="Config option to describe. For a "
-                "comprehensive list of options, "
-                "run `pybm config list`.",
+                "comprehensive list of options, run `pybm config list`.",
             )
 
     @contextlib.contextmanager
@@ -82,7 +81,7 @@ class ConfigCommand(CLICommand):
         attr: str = options.option
 
         with self.context("get", attr, None, verbose):
-            value = PybmConfig.load(".pybm/config.yaml").get_value(attr)
+            value = PybmConfig.load(".pybm/config.toml").get_value(attr)
 
         if is_dataclass(value):
             for k, v in asdict(value).items():
@@ -96,7 +95,7 @@ class ConfigCommand(CLICommand):
         verbose: bool = options.verbose
 
         attr, value = str(options.option), str(options.value)
-        path = ".pybm/config.yaml"
+        path = ".pybm/config.toml"
 
         with self.context("set", attr, value, verbose):
             PybmConfig.load(path).set_value(attr, value).save(path)
@@ -105,7 +104,7 @@ class ConfigCommand(CLICommand):
 
     @staticmethod
     def list(options: argparse.Namespace) -> int:
-        config = PybmConfig.load(".pybm/config.yaml")
+        config = PybmConfig.load(".pybm/config.toml")
 
         for name in get_all_names(config):
             group = config.get_value(name)
@@ -128,7 +127,7 @@ class ConfigCommand(CLICommand):
                 "be described via `pybm config describe`."
             )
 
-        config = PybmConfig.load(".pybm/config.yaml")
+        config = PybmConfig.load(".pybm/config.toml")
         config.describe(attr)
 
         return SUCCESS

--- a/pybm/commands/env.py
+++ b/pybm/commands/env.py
@@ -31,7 +31,7 @@ class EnvCommand(CLICommand):
 
     def __init__(self):
         super(EnvCommand, self).__init__(name="env")
-        config = PybmConfig.load(".pybm/config.yaml")
+        config = PybmConfig.load()
         self.config = config
 
     def add_arguments(self, subcommand: str = None):

--- a/pybm/commands/init.py
+++ b/pybm/commands/init.py
@@ -83,18 +83,17 @@ class InitCommand(CLICommand):
 
         config_dir = Path(options.config_dir)
         config_dir.mkdir(parents=True, exist_ok=True)
-        config_path = config_dir / "config.yaml"
+        config_path = config_dir / "config.toml"
 
         if options.remove_existing:
-            for p in list_contents(config_dir, file_suffix=".yaml", names_only=True):
+            for p in list_contents(config_dir, file_suffix=".toml", names_only=True):
                 (config_dir / p).unlink()
 
         if config_path.exists():
             raise PybmError(
                 "Configuration file already exists. "
                 "If you want to write a new config file, "
-                'please specify the "--rm" option '
-                "to `pybm init`."
+                "please specify the '--rm' option to `pybm init`."
             )
         else:
             config.save(config_path)

--- a/pybm/commands/report.py
+++ b/pybm/commands/report.py
@@ -18,7 +18,7 @@ class ReportCommand(CLICommand):
 
     def __init__(self):
         super(ReportCommand, self).__init__(name="report")
-        self.config = PybmConfig.load(".pybm/config.yaml")
+        self.config = PybmConfig.load()
 
     def add_arguments(self):
         self.parser.add_argument(

--- a/pybm/commands/run.py
+++ b/pybm/commands/run.py
@@ -21,7 +21,7 @@ class RunCommand(CLICommand):
 
     def __init__(self):
         super(RunCommand, self).__init__(name="run")
-        self.config = PybmConfig.load(".pybm/config.yaml")
+        self.config = PybmConfig.load()
 
     def add_arguments(self):
         self.parser.add_argument(
@@ -30,8 +30,7 @@ class RunCommand(CLICommand):
             help="Name of the benchmark target(s) to "
             "run. Can be a path to a single file, "
             "a directory, or a glob expression. "
-            "Given paths need to be relative to "
-            "the worktree root.",
+            "Given paths need to be relative to the worktree root.",
             metavar="<benchmark>",
         )
         self.parser.add_argument(
@@ -53,8 +52,7 @@ class RunCommand(CLICommand):
             default=False,
             dest="run_as_module",
             help="Run benchmark targets as modules. "
-            "Use this to benchmark code "
-            "outside of a package.",
+            "Use this to benchmark code outside of a package.",
         )
         self.parser.add_argument(
             "--checkout",
@@ -170,18 +168,16 @@ class RunCommand(CLICommand):
                     "The --all switch can only be used as a "
                     "substitute for specific environment IDs, but "
                     "the following environments were requested: "
-                    f"{', '.join(env_ids)}. Please either omit "
-                    f"the --all switch or the specific "
-                    f"environment IDs."
+                    f"{', '.join(env_ids)}. Please either omit the "
+                    f"--all switch or the specific environment IDs."
                 )
         else:
             if checkout_mode:
                 raise PybmError(
                     "When running in checkout mode, please specify at "
                     "least one valid git reference to benchmark. To "
-                    "benchmark the current checkout in the "
-                    '"root" environment, use the command '
-                    f"`pybm run {source_path} root`."
+                    "benchmark the current checkout in the 'root'"
+                    "environment, use the command `pybm run {source_path} root`."
                 )
 
             if not run_all and len(env_store.environments) > 1:
@@ -189,14 +185,13 @@ class RunCommand(CLICommand):
                     "No environments were specified as "
                     "positional arguments to `pybm run`, "
                     "but more than one environment exists "
-                    "in the current repository. Please "
-                    "supply your desired target environments "
-                    "specifically when calling `pybm run`, or "
-                    "use the --all switch."
+                    "in the current repository. Please supply "
+                    "the desired target environments specifically"
+                    "when calling `pybm run`, or use the --all switch."
                 )
 
         if run_all:
-            env_ids = [env.name for env in env_store.environments]
+            env_ids = list(env_store.environments.keys())
 
         # in order to revert to original checkout after benchmarks
         root_checkout = env_store.get("root").worktree.get_ref_and_type()

--- a/pybm/config.py
+++ b/pybm/config.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, asdict
 from pathlib import Path
 from typing import Union, Dict, List
 
-import yaml
+import toml
 
 from pybm.exceptions import PybmError
 from pybm.mixins import StateMixin
@@ -23,6 +23,8 @@ __all__ = [
 
 Descriptions = Dict[str, str]
 
+CONFIG = ".pybm/config.toml"
+
 
 @dataclass
 class PybmConfig(StateMixin):
@@ -33,7 +35,7 @@ class PybmConfig(StateMixin):
     reporter: ReporterGroup = ReporterGroup()
 
     @classmethod
-    def load(cls, path: Union[str, pathlib.Path]):
+    def load(cls, path: Union[str, pathlib.Path] = CONFIG):
         if isinstance(path, str):
             path = Path(path)
 
@@ -45,7 +47,7 @@ class PybmConfig(StateMixin):
             )
 
         with open(path, "r") as config_file:
-            spec = yaml.load(config_file, Loader=yaml.FullLoader)
+            spec = toml.load(config_file)
 
         return PybmConfig(
             core=CoreGroup(**spec["core"]),
@@ -66,7 +68,7 @@ class PybmConfig(StateMixin):
 
     def save(self, path: Union[str, pathlib.Path]):
         with open(path, "w") as config_file:
-            yaml.dump(self.to_dict(), config_file)
+            toml.dump(self.to_dict(), config_file)
 
     def describe(self, attr):
         current = self.get_value(attr)
@@ -130,12 +132,11 @@ description_db: Dict[str, Descriptions] = {
         "https://docs.python.org/3/library/logging.html#formatter-objects.",
     },
     "git": {
-        "createWorktreeInParentDirectory": "Whether to create worktrees "
-        "in the parent directory of your git repository by default. "
+        "basedir": "Where to create new git worktrees. This value is set with the "
+        "parent directory of your repository as default. "
         "Some IDEs may get confused when you initialize another "
         "git worktree inside your main repository, so this option "
-        "provides a way to keep your main repo folder clean without having "
-        "to explicitly type '../my-dir' every time you create a git worktree.",
+        "provides an easy way to maintain a clean repository.",
     },
     "builder": {
         "name": "Name of the builder class used in pybm to manage "

--- a/pybm/env_store.py
+++ b/pybm/env_store.py
@@ -2,9 +2,9 @@ import sys
 from contextlib import ExitStack
 from datetime import datetime
 from pathlib import Path
-from typing import List, Any, Optional
+from typing import Any, Optional, Dict
 
-import yaml
+import toml
 
 from pybm import PybmConfig
 from pybm.builders import BaseBuilder
@@ -13,7 +13,7 @@ from pybm.config import get_builder_class, get_runner_requirements
 from pybm.exceptions import PybmError
 from pybm.git import GitWorktreeWrapper
 from pybm.specs import Worktree, PythonSpec, BenchmarkEnvironment
-from pybm.util.common import lmap
+from pybm.util.common import dvmap
 from pybm.util.git import disambiguate_info, is_main_worktree
 from pybm.util.print import (
     abbrev_home,
@@ -50,7 +50,7 @@ class EnvironmentStore:
         self.verbose = verbose
         self.missing_ok = missing_ok
 
-        self.environments: List[BenchmarkEnvironment] = []
+        self.environments: Dict[str, BenchmarkEnvironment] = {}
         self.load()
 
     def load(self):
@@ -71,15 +71,16 @@ class EnvironmentStore:
                 )
 
             with open(self.env_file, "r") as cfg:
-                envs = yaml.load(cfg, Loader=yaml.FullLoader)
+                envs = toml.load(cfg)
 
             if self.verbose:
                 print("done.")
 
-            self.environments = lmap(BenchmarkEnvironment.from_dict, envs)
+            for name, info in envs.items():
+                self.environments[name] = BenchmarkEnvironment.from_dict(name, info)
 
     def save(self):
-        envs = lmap(lambda x: x.to_dict(), self.environments)
+        envs = dvmap(lambda x: x.to_dict(), self.environments)
 
         if self.verbose:
             print(
@@ -88,7 +89,7 @@ class EnvironmentStore:
             )
 
         with open(self.env_file, "w") as cfg:
-            yaml.dump(envs, cfg)
+            toml.dump(envs, cfg)
 
         if self.verbose:
             print("done.")
@@ -152,10 +153,10 @@ class EnvironmentStore:
                 worktree=worktree,
                 python=python_spec,
                 created=created,
-                last_modified=created,
+                lastmod=created,
             )
 
-            self.environments.append(environment)
+            self.environments[name] = environment
 
             print(f"Successfully created benchmark environment for ref {commit_ish!r}.")
 
@@ -185,7 +186,7 @@ class EnvironmentStore:
 
             git_worktree.remove(str(worktree_root), force=force)
 
-            self.environments.remove(env_to_remove)
+            env_to_remove = self.environments.pop(env_name)
 
             print(f"Successfully removed benchmark environment {env_name!r}.")
 
@@ -204,17 +205,17 @@ class EnvironmentStore:
             if info is not None:
                 env = next(
                     e
-                    for e in self.environments
+                    for e in self.environments.values()
                     if e.worktree == git_worktree.get_worktree_by_attr(info, value)
                 )
             else:
-                env = next(e for e in self.environments if e.name == value)
+                env = self.environments[value]
 
             if self.verbose:
                 print("success.")
 
             return env
-        except StopIteration:
+        except (StopIteration, KeyError):
             if self.verbose:
                 print("failed.")
 
@@ -232,7 +233,7 @@ class EnvironmentStore:
         ]
 
         env_data = [column_names]
-        for env in self.environments:
+        for env in self.environments.values():
             root: str = env.get_value("worktree.root")
 
             values = [env.get_value("name")]
@@ -274,10 +275,10 @@ class EnvironmentStore:
                     worktree=worktree,
                     python=python_spec,
                     created=created,
-                    last_modified=created,
+                    lastmod=created,
                 )
 
-                self.environments.append(env)
+                self.environments[name] = env
 
     def switch(self, name: str, ref: str) -> BenchmarkEnvironment:
         git_worktree: GitWorktreeWrapper = GitWorktreeWrapper(config=self.config)
@@ -291,8 +292,7 @@ class EnvironmentStore:
 
             if self.verbose:
                 print(
-                    f"Switching checkout of environment {env.name!r} to "
-                    f"{ref_type} {ref!r}."
+                    f"Switching checkout of environment {name!r} to {ref_type} {ref!r}."
                 )
 
             worktree = git_worktree.switch(

--- a/pybm/specs.py
+++ b/pybm/specs.py
@@ -29,8 +29,8 @@ class Worktree:
 
     root: str
     commit: str
-    branch: Optional[str]
-    tag: Optional[str]
+    branch: Optional[str] = None
+    tag: Optional[str] = None
 
     @classmethod
     def from_list(cls, wt_info: List[str]):
@@ -74,16 +74,16 @@ class BenchmarkEnvironment(StateMixin):
     worktree: Worktree
     python: PythonSpec
     created: str
-    last_modified: str
+    lastmod: str
 
     @classmethod
-    def from_dict(cls, spec: Dict[str, Any]):
+    def from_dict(cls, name: str, spec: Dict[str, Any]):
         return BenchmarkEnvironment(
-            name=spec["name"],
+            name=name,
             worktree=Worktree(**spec["worktree"]),
             python=PythonSpec(**spec["python"]),
             created=spec["created"],
-            last_modified=spec["last_modified"],
+            lastmod=spec["lastmod"],
         )
 
     def to_dict(self):
@@ -92,14 +92,14 @@ class BenchmarkEnvironment(StateMixin):
             "worktree": asdict(self.worktree),
             "python": asdict(self.python),
             "created": self.created,
-            "last_modified": self.last_modified,
+            "lastmod": self.lastmod,
         }
 
 
 @dataclass
 class CoreGroup:
     datefmt: str = "%d/%m/%Y, %H:%M:%S"
-    envfile: str = ".pybm/envs.yaml"
+    envfile: str = ".pybm/envs.toml"
     logfile: str = "logs/logs.txt"
     logfmt: str = "%(asctime)s — %(name)-12s " "— %(levelname)s — %(message)s"
     loglevel: int = logging.DEBUG
@@ -108,7 +108,7 @@ class CoreGroup:
 
 @dataclass
 class GitGroup:
-    createWorktreeInParentDirectory: bool = True
+    basedir: str = ".."
 
 
 @dataclass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pyyaml
+toml
 dataclasses; python_version<"3.7"


### PR DESCRIPTION
Fixes #22.

This commit contains the move from YAML to TOML for all pybm configuration files.

All YAML calls have been substituted for their respective TOML calls. Mypy configuration was adapted to TOML, as was the readme note and requirements.txt file.

Due to TOML's object hierarchy, which prevents list-like structures, the benchmark environment container in the `EnvironmentStore` was changed from a list to a dict.
All discovery methods, lifecycle management and other APIs were adapted to this circumstance.

Previously hardcoded config paths across the project were changed to a single constant embedded in the `pybm.config` module, which is also the default value for the `PybmConfig.load()` API.