### PR TITLE
Implement legacy sourcing via git checkout

### DIFF
--- a/pybm/config.py
+++ b/pybm/config.py
@@ -119,6 +119,11 @@ description_db: Dict[str, Descriptions] = {
         "parent directory of your repository as default. Some IDEs may get confused "
         "when you initialize another git worktree inside your main repository, so "
         "this option provides an easy way to maintain a clean repository.",
+        "legacycheckout": "Whether to use the `git checkout <ref> -- <source>` "
+        "command to source benchmark files from another ref instead of `git "
+        "restore --source <ref> <source>`. The latter command is better suited for "
+        "this purpose, but requires at minimum git 2.23. Setting this option to 'true' "
+        "allows the use of older git versions for this purpose.",
     },
     "builder": {
         "name": "Name of the builder class used in pybm to manage "

--- a/pybm/specs.py
+++ b/pybm/specs.py
@@ -109,6 +109,7 @@ class CoreGroup:
 @dataclass
 class GitGroup:
     basedir: str = ".."
+    legacycheckout: bool = False
 
 
 @dataclass


### PR DESCRIPTION
Fixes #18.

The config option `git.legacycheckout` was introduced for legacy benchmark sourcing via `git checkout`.