### PR TITLE
Add global configuration file

### DIFF
--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -52,6 +52,7 @@ resultdir = "results"
 
 [git]
 basedir = ".."
+legacycheckout = false
 
 [runner]
 name = "pybm.runners.TimeitRunner"
@@ -70,8 +71,6 @@ pipuninstalloptions = ""
 name = "pybm.reporters.ConsoleReporter"
 timeunit = "usec"
 significantdigits = 2
-
-
 ```
 
 ## `pybm config describe`
@@ -82,7 +81,12 @@ type, its current value, and a small help text:
 ```shell
 ➜ pybm config describe runner.name
 Describing configuration option 'runner.name'.
-Value type:    str
+Value type: str
 Current value: 'pybm.runners.TimeitRunner'
 Name of the runner class used in pybm to run benchmarks inside Python virtual environments. If you want to supply your own custom runner class, set this value to your custom subclass of pybm.runners.BaseRunner.
 ```
+
+## Working with the global config
+
+All the above methods can be used to manage a global configuration file as well, which can be used to set system-wide 
+defaults. To do this, simply supply the `--global` switch to any of the above commands.

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -1,22 +1,21 @@
 # The `init` command
 
 ```shell
-➜ pybm init -h
-usage: pybm init <config-dir> [<options>]
+➜ pybm init -h               
+usage: pybm init [<options>]
 
     Initialize pybm in a git repository by adding a configuration file
     and an environment list into a directory.
     
-
-positional arguments:
-  <config-dir>          Directory in which to store the pybm configuration data.
 
 optional arguments:
   -h, --help            Show this message and exit.
   -v                    Enable verbose mode. Makes pybm log information that might be useful for debugging.
   --rm                  Overwrite existing configuration.
   -o OVERRIDES, --override OVERRIDES
-                        Override a value by hand for the newly created pybm configuration file.
+                        Override a specific configuration setting with a custom value for the new pybm configuration file. Supplied arguments need to have the form 'key=value'. For a comprehensive list of
+                        configuration options, run `pybm config list`.
+  --skip-global         Skip applying system-wide defaults set in the global config file to the newly created pybm configuration.
 ```
 
 The `pybm init` command creates a configuration file and a state file that tracks the currently available benchmark
@@ -38,3 +37,6 @@ command `pybm config list`.)
 The `-o` switch can be used multiple times to set multiple different values at the same time. If you have a lot of
 default values that you want to set, and do not want to type out long commands each time, consider writing a global pybm
 config - this feature will be added in an upcoming release.
+
+By default, if a global config file is present, global values are used as defaults when running `pybm init`. If you 
+want to avoid adopting global settings locally, you can supply the `--skip-global` switch to `pybm init`.

--- a/examples/sum-example.md
+++ b/examples/sum-example.md
@@ -184,14 +184,12 @@ benchmark->save-results kind of workflow, we obtained all the results we need in
 ## And finally... the numbers
 
 Lastly, we need to check how big our improvements actually are (or rather, if we have achieved any in the first place!).
-This is handled by the
-`pybm compare` command, which compares all measured results to a "frame of reference"
-branch, which is taken to be the baseline for performance comparisons. In our case, that is our fictitious math
-library's current
-`master`.
+This is handled by the `pybm compare` command, which compares all measured results to a "frame of reference" branch,
+which is taken to be the baseline for performance comparisons. In our case, that is our fictitious math library's
+current `master`.
 
 ```shell
-pybm compare latest master linear-time constant-time
+pybm compare master linear-time constant-time
 
  Benchmark Name      | Ref           | Wall Time (usec) | CPU Time (usec) | Δt_rel (master) | Speedup      | Iterations
 ---------------------+---------------+------------------+-----------------+-----------------+--------------+------------
@@ -200,10 +198,10 @@ pybm compare latest master linear-time constant-time
  benchmarks/sum.py:f | constant-time | 0.13             | 0.12            | -100.00%        | 10759575.02x | 2000000   
 ```
 
-And look here, instead of 10x-ing our previous algorithm like a normal engineer, we actually... 10-million-x-ed it.
+And look here, instead of 10x-ing our previous algorithm like a normal engineer, we actually 10-million-x-ed it.
 Great work! Our constant time algorithm is definitely ready for a pull request :-)
 
 These are of course video game numbers, obtained by algorithmic improvements. More common real-world examples would see
 improvements in the one-to-three digit percentage range, but the example you see above does happen from time to time.
 
-And with that, the first pybm tutorial is finished. I hope you enjoyed it, and catch you on the next one!
+And with that, the first `pybm` tutorial is finished. I hope you enjoyed it, and catch you on the next one!

--- a/pybm/builders/util.py
+++ b/pybm/builders/util.py
@@ -82,7 +82,7 @@ def is_valid_venv(path: Union[str, Path], verbose: bool = False) -> bool:
         return False
 
     if verbose:
-        print("successful.")
+        print("success.")
     return True
 
 

--- a/pybm/env_store.py
+++ b/pybm/env_store.py
@@ -8,7 +8,6 @@ import toml
 
 from pybm import PybmConfig
 from pybm.builders import BaseBuilder
-from pybm.builders.util import is_valid_venv
 from pybm.config import get_component_class, get_runner_requirements
 from pybm.exceptions import PybmError
 from pybm.git import GitWorktreeWrapper
@@ -254,9 +253,7 @@ class EnvironmentStore:
             for i, worktree in enumerate(self.git_worktree.list()):
                 venv_root = Path(worktree.root) / "venv"
 
-                if venv_root.exists() and is_valid_venv(
-                    venv_root, verbose=self.verbose
-                ):
+                if venv_root.exists():
                     python_spec = self.builder.link(venv_root, verbose=self.verbose)
                 else:
                     # TODO: Enable auto-grabbing from venv home

--- a/pybm/mixins.py
+++ b/pybm/mixins.py
@@ -28,7 +28,7 @@ class StateMixin:
             else:
                 return default
 
-    def set_value(self, attr: str, value: Any):
+    def set_value(self, attr: str, value: str):
         *keys, subkey = attr.split(".")
         obj: Any = self
 
@@ -47,6 +47,8 @@ class StateMixin:
 
     @staticmethod
     def canonicalize_type(obj, attr: str, value: str):
+        assert value is not None, "cannot set None config value"
+
         annotations = obj.__annotations__
 
         # if no annotation exists (this should not happen), interpret as string
@@ -70,9 +72,7 @@ class StateMixin:
 
         except ValueError:
             raise PybmError(
-                f"Configuration value {attr!r} of class "
-                f"{obj.__class__.__name__} has to be of type "
-                f"{target_type.__name__!r}, but the given "
-                f"value {value!r} could not be "
-                f"interpreted as such."
+                f"Configuration value {attr!r} of class {obj.__class__.__name__} has "
+                f"to be of type {target_type.__name__!r}, but the given value "
+                f"{value!r} could not be interpreted as such."
             )

--- a/pybm/specs.py
+++ b/pybm/specs.py
@@ -1,5 +1,5 @@
 import logging
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, field, asdict, is_dataclass
 from typing import List, Optional, Dict, Any, Tuple
 
 from pybm.exceptions import GitError
@@ -88,20 +88,16 @@ class BenchmarkEnvironment(StateMixin):
 
     def to_dict(self):
         return {
-            "name": self.name,
-            "worktree": asdict(self.worktree),
-            "python": asdict(self.python),
-            "created": self.created,
-            "lastmod": self.lastmod,
+            k: asdict(v) if is_dataclass(v) else v for k, v in self.__dict__.items()
         }
 
 
 @dataclass
 class CoreGroup:
-    datefmt: str = "%d/%m/%Y, %H:%M:%S"
+    datefmt: str = "%d/%m/%Y %H:%M:%S"
     envfile: str = ".pybm/envs.toml"
     logfile: str = "logs/logs.txt"
-    logfmt: str = "%(asctime)s — %(name)-12s " "— %(levelname)s — %(message)s"
+    logfmt: str = "%(asctime)s — %(name)-12s — %(levelname)s — %(message)s"
     loglevel: int = logging.DEBUG
     resultdir: str = "results"
 


### PR DESCRIPTION
Fixes #21.

This commit adds a global configuration file to `pybm`, which can be used to set system-wide defaults for initialized pybm configurations similar to git's config system.

* The `--global` switch was added to the `pybm config` command, which allows manipulating the global config object similar to the local one.
* keys, values, and items methods were added to the PybmConfig interface to emulate dictionary functionality for the config.
* A `from_dict` classmethod was added to initialize a PybmConfig from a dictionary object.
* A `--skip-global` switch was added to `pybm init` to skip initialization of a local config with global values.