### PR TITLE
Add package validation logic

### DIFF
--- a/pybm/runners/gbm.py
+++ b/pybm/runners/gbm.py
@@ -5,6 +5,7 @@ import pybm.runners.util as runner_util
 from pybm import PybmError
 from pybm.config import PybmConfig
 from pybm.runners.base import BaseRunner
+from pybm.specs import Package
 from pybm.util.common import lfilter
 from pybm.util.extras import get_extras
 
@@ -24,14 +25,13 @@ class GoogleBenchmarkRunner(BaseRunner):
     """
 
     def __init__(self, config: PybmConfig):
-        self.required_packages = get_extras()["gbm"]
         if not GBM_INSTALLED:
             raise PybmError(
                 "Missing dependencies. You attempted to use the "
                 "Google Benchmark runner without having the "
                 "required dependencies installed. To do so, "
                 "please run the command `pybm env install root "
-                f"{' '.join(self.required_packages)}` while "
+                f"{' '.join([str(p) for p in self.required_packages])}` while "
                 f"inside your root virtual environment.\n "
                 f"BEWARE: As of 10/2021, Google Benchmark does "
                 f"not have source wheels available for any "
@@ -52,20 +52,24 @@ class GoogleBenchmarkRunner(BaseRunner):
                 "flags": "--enable-random-interleaving",
                 "action": "store_true",
                 "default": False,
-                "help": "Whether to enable the random interleaving feature "
-                "in Google Benchmark. This can reduce run-to-run "
-                "variance by running benchmarks in random order.",
+                "help": "Whether to enable the random interleaving feature in Google "
+                "Benchmark. This can reduce run-to-run variance by running benchmarks "
+                "in random order.",
             },
             {
                 "flags": "--report-aggregates-only",
                 "action": "store_true",
                 "default": False,
-                "help": "Whether to report aggregates (mean/stddev) only "
-                "in Google Benchmark instead of the raw data. If you uncheck this "
-                "option, mean/median/stddev aggregates are still reported if the "
-                "number of repetitions is greater than 1.",
+                "help": "Whether to report aggregates (mean/stddev) only instead of "
+                "the raw data in Google Benchmark. If you uncheck this option, "
+                "mean/median/stddev aggregates are still reported if the number of "
+                "benchmark repetitions is greater than 1.",
             },
         ]
+
+    @property
+    def required_packages(self) -> List[Package]:
+        return get_extras()["gbm"]
 
     def run_benchmark(
         self, argv: Optional[List[str]] = None, module_context: Dict[str, Any] = None

--- a/pybm/specs.py
+++ b/pybm/specs.py
@@ -1,4 +1,5 @@
 import logging
+import typing
 from dataclasses import dataclass, field, asdict, is_dataclass
 from typing import List, Optional, Dict, Any, Tuple
 
@@ -6,6 +7,22 @@ from pybm.exceptions import GitError
 from pybm.mixins import StateMixin
 from pybm.util.git import map_commits_to_tags
 from pybm.util.subprocess import run_subprocess
+
+
+class Package(typing.NamedTuple):
+    name: str
+    version: Optional[str] = None
+    origin: Optional[str] = None
+
+    def __str__(self):
+        if self.version is not None and self.origin is None:
+            return self.name + "==" + self.version
+        elif self.version is not None and self.origin is not None:
+            return self.origin + "@" + self.version
+        elif self.version is None and self.origin is not None:
+            return self.origin
+        else:
+            return self.name
 
 
 @dataclass(frozen=True)
@@ -112,6 +129,7 @@ class GitGroup:
 class BuilderGroup:
     name: str = "pybm.builders.VenvBuilder"
     homedir: str = ""
+    autoinstall: bool = True
     wheelcaches: str = ""
     venvoptions: str = ""
     pipinstalloptions: str = ""

--- a/pybm/util/extras.py
+++ b/pybm/util/extras.py
@@ -1,6 +1,18 @@
+from typing import List
+
+from pybm.specs import Package
+
+
 def get_extras():
     """Extra pybm functionality, specified as a valid argument to
     setuptools.setup's 'extras_require' keyword argument."""
-    extra_features = {"gbm": ["pybm", "google-benchmark"]}
-    extra_features["all"] = sum(extra_features.values(), [])
+    extra_features = {
+        "gbm": [
+            Package("pybm", origin="https://github.com/nicholasjng/pybm"),
+            Package("google-benchmark", origin="https://github.com/google/benchmark"),
+        ]
+    }
+    # be explicit here for mypy
+    start: List[Package] = []
+    extra_features["all"] = sum(extra_features.values(), start)
     return extra_features


### PR DESCRIPTION
This commit improves required package validation in pybm class components. This change was necessary to handle runner dependencies especially, which need to be installed into the created benchmark environments and thus validated before benchmark runs.

To this end, a barebones namedtuple called Package was introduced, containing the package name and, optionally, the required version number and origin (useful e.g. for projects from GitHub). This way, confusing string splitting and version parsing can be avoided.