### PR TITLE
Make time processing optional, abbreviate home with proper Pathlib APIs

### DIFF
--- a/pybm/git.py
+++ b/pybm/git.py
@@ -13,7 +13,7 @@ from pybm.util.git import (
     disambiguate_info,
     resolve_ref,
     is_main_worktree,
-    checkout,
+    checkout as git_checkout,
     resolve_commit,
 )
 from pybm.util.path import current_folder
@@ -325,7 +325,7 @@ class GitWorktreeWrapper:
                 f"Object {ref!r} could not be understood as a valid git reference."
             )
 
-        checkout(ref=ref, cwd=worktree.root)
+        git_checkout(ref=ref, cwd=worktree.root)
 
         # null the old reference type if necessary
         if ref_type != old_type:

--- a/pybm/reporters/util.py
+++ b/pybm/reporters/util.py
@@ -91,7 +91,6 @@ def log_to_console(results: List[Dict[str, str]], padding: int = 1):
             print(make_separator(column_widths, padding=padding))
 
         print(make_line(res.values(), column_widths, padding=padding))
-        # TODO: Print summary about improvements etc.
 
 
 def reduce(results: List[Dict[str, Any]]) -> Dict[str, Any]:

--- a/pybm/util/print.py
+++ b/pybm/util/print.py
@@ -5,8 +5,14 @@ from pybm.util.common import lmap
 
 
 def abbrev_home(path: Union[str, Path]) -> str:
-    homepath = Path(path).resolve().relative_to(Path.home())
-    return str(Path("~") / homepath)
+    path = Path(path).resolve()
+    try:
+        homepath = path.relative_to(Path.home())
+        abbrev_path = str(Path("~") / homepath)
+    except ValueError:
+        # case where the env path is not a subpath of the home directory
+        abbrev_path = str(path)
+    return abbrev_path
 
 
 def calculate_column_widths(data: Iterable[Iterable[str]]) -> List[int]:
@@ -17,9 +23,8 @@ def calculate_column_widths(data: Iterable[Iterable[str]]) -> List[int]:
 def make_line(values: Iterable[str], column_widths: Iterable[int], padding: int) -> str:
     pad_char = " " * padding
     sep = "|".join([pad_char] * 2)
-    offset = pad_char
 
-    line = offset + sep.join(f"{n:<{w}}" for n, w in zip(values, column_widths))
+    line = pad_char + sep.join(f"{n:<{w}}" for n, w in zip(values, column_widths))
     return line
 
 


### PR DESCRIPTION
This commit contains two main fixes:
1) Time values are now processed conditionally on whether a "time_unit" key is found in the benchmark object.
2) The `abbrev_home` function now collapses the home directory with only pathlib's APIs.